### PR TITLE
[DI] Add ivory.serializer.loader tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_script:
     - composer self-update
     - composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
-    - if [[ "$SYMFONY_VERSION" = 3.* ]]; then composer require --no-update --dev symfony/cache:${SYMFONY_VERSION}; fi
+    - if [[ "$SYMFONY_VERSION" =~ ^3\.[1-9][0-9]? ]]; then composer require --no-update --dev symfony/cache:${SYMFONY_VERSION}; fi
     - composer remove --no-update --dev friendsofphp/php-cs-fixer
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
     - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`

--- a/DependencyInjection/Compiler/RegisterClassMetadataLoaderPass.php
+++ b/DependencyInjection/Compiler/RegisterClassMetadataLoaderPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Ivory Serializer bundle package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\SerializerBundle\DependencyInjection\Compiler;
+
+use Ivory\Serializer\Mapping\Loader\ChainClassMetadataLoader;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class RegisterClassMetadataLoaderPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $loaders = array_keys($container->findTaggedServiceIds($tag = 'ivory.serializer.loader'));
+
+        if (empty($loaders)) {
+            throw new \RuntimeException(sprintf(
+                'You must define at least one class metadata loader by enabling the reflection loader in your '.
+                'configuration or by registering a loader in the container with the tag "%s".',
+                $tag
+            ));
+        }
+
+        $loader = 'ivory.serializer.mapping.loader';
+
+        if (count($loaders) > 1) {
+            $container->setDefinition($loader, new Definition(ChainClassMetadataLoader::class, [
+                array_map(function ($service) {
+                    return new Reference($service);
+                }, $loaders),
+                new Reference('ivory.serializer.type.parser'),
+            ]));
+        } else {
+            $container->setAlias($loader, array_shift($loaders));
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,7 +13,6 @@ namespace Ivory\SerializerBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -30,7 +29,6 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = $this->createTreeBuilder();
         $treeBuilder->root('ivory_serializer')
             ->children()
-            ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
             ->append($this->createMappingNode())
             ->append($this->createTypesNode())
             ->append($this->createVisitorsNode());
@@ -46,6 +44,15 @@ class Configuration implements ConfigurationInterface
         return $this->createNode('mapping')
             ->addDefaultsIfNotSet()
             ->children()
+                ->booleanNode('annotation')->defaultValue(class_exists(AnnotationReader::class))->end()
+                ->booleanNode('reflection')->defaultTrue()->end()
+                ->arrayNode('cache')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('prefix')->defaultValue('ivory_serializer')->end()
+                        ->scalarNode('pool')->defaultValue('cache.system')->end()
+                    ->end()
+                ->end()
                 ->arrayNode('auto')
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -64,8 +71,6 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('paths')
                     ->prototype('scalar')->end()
                 ->end()
-                ->booleanNode('annotations')->defaultValue(class_exists(AnnotationReader::class))->end()
-                ->scalarNode('cache')->end()
             ->end();
     }
 
@@ -135,13 +140,12 @@ class Configuration implements ConfigurationInterface
 
     /**
      * @param string $name
-     * @param string $type
      *
-     * @return ArrayNodeDefinition|NodeDefinition
+     * @return ArrayNodeDefinition
      */
-    private function createNode($name, $type = 'array')
+    private function createNode($name)
     {
-        return $this->createTreeBuilder()->root($name, $type);
+        return $this->createTreeBuilder()->root($name);
     }
 
     /**

--- a/IvorySerializerBundle.php
+++ b/IvorySerializerBundle.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\SerializerBundle;
 
+use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterClassMetadataLoaderPass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterTypePass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterVisitorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,6 +28,7 @@ class IvorySerializerBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container
+            ->addCompilerPass(new RegisterClassMetadataLoaderPass())
             ->addCompilerPass(new RegisterTypePass())
             ->addCompilerPass(new RegisterVisitorPass());
     }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,31 @@
 The bundle provides an integration of the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) library for
 your Symfony2 project.
 
+``` php
+use Ivory\Serializer\Format;
+
+$stdClass = new \stdClass();
+$stdClass->foo = true;
+$stdClass->bar = ['foo', [123, 432.1]];
+
+$serializer = $container->get('ivory.serializer');
+
+echo $serializer->serialize($stdClass, Format::JSON);
+// {"foo": true,"bar": ["foo", [123, 432.1]]}
+
+$deserialize = $serializer->deserialize($json, \stdClass::class, Format::JSON);
+// $deserialize == $stdClass
+```
+
 ## Documentation
 
  - [Installation](/Resources/doc/installation.md)
- - FIXME ...
+ - [Usage](/Resources/doc/usage.md)
+ - [Configuration](/Resources/doc/configuration/index.md)
+    - [Mapping](/Resources/doc/configuration/mapping.md)
+    - [Type](/Resources/doc/configuration/type.md)
+    - [Visitor](/Resources/doc/configuration/visitor.md)
+    - [Cache](/Resources/doc/configuration/cache.md)
 
 ## Testing
 

--- a/Resources/config/cache.xml
+++ b/Resources/config/cache.xml
@@ -8,17 +8,12 @@
 >
     <services>
         <service
-            id="ivory.serializer.mapping.factory"
-            class="Ivory\Serializer\Mapping\Factory\CacheClassMetadataFactory"
+            id="ivory.serializer.cache_warmer"
+            class="Ivory\SerializerBundle\CacheWarmer\SerializerCacheWarmer"
         >
-            <argument type="service" id="ivory.serializer.mapping.factory.default" />
-        </service>
-
-        <service
-            id="ivory.serializer.mapping.factory.default"
-            class="Ivory\Serializer\Mapping\Factory\ClassMetadataFactory"
-        >
+            <argument type="service" id="ivory.serializer.mapping.factory" />
             <argument type="service" id="ivory.serializer.mapping.loader" />
+            <tag name="kernel.cache_warmer" />
         </service>
     </services>
 </container>

--- a/Resources/doc/configuration/cache.md
+++ b/Resources/doc/configuration/cache.md
@@ -1,0 +1,3 @@
+# Cache
+
+FIXME

--- a/Resources/doc/configuration/index.md
+++ b/Resources/doc/configuration/index.md
@@ -1,0 +1,8 @@
+# Configuration
+
+The configuration allows you to set up the serializer the way you want instead of the default one.
+
+ - [Mapping](/Resources/doc/configuration/mapping.md)
+ - [Types](/Resources/doc/configuration/types.md)
+ - [Visitors](/Resources/doc/configuration/visitors.md)
+ - [Cache](/Resources/doc/configuration/cache.md)

--- a/Resources/doc/configuration/mapping.md
+++ b/Resources/doc/configuration/mapping.md
@@ -1,0 +1,106 @@
+# Mapping
+
+The mapping configuration allows you to configure how and where metadatas are loaded by the Serializer.
+
+## Auto Mapping
+
+By default, the bundle automatically registers the following directory and files for each bundles (if they exist):
+
+```
+Resources/config/serializer
+Resources/config/serializer.json
+Resources/config/serializer.xml
+Resources/config/serializer.yml
+```
+
+That means you just need to put your metadatas in the `Resources/config/serializer` directory or in the 
+`Resources/config/serializer.(json|xml|yml)` file of your bundle.
+
+Hopefully, these paths are configurable. If you would prefer to use the `Resources/config/serialization` directory as 
+well as the `Resources/config/serialization.(json|xml|yml)`, you can use: 
+
+``` yaml
+ivory_serializer:
+    mapping:
+        auto:
+            paths:
+                - Resources/config/serialization
+                - Resources/config/serialization.json
+                - Resources/config/serialization.xml
+                - Resources/config/serialization.yml
+```
+
+If you don't want to use the auto mapping feature, you can disable it:
+
+``` yaml
+ivory_serializer:
+    mapping:
+        auto:
+            enabled: false
+```
+
+## Manual Mapping
+
+The manual mapping allows you to expose global paths to the serializer:
+
+``` yaml
+ivory_serializer:
+    mapping:
+        paths:
+            - %kernel.root_dir%/Resources/serializer
+            - %kernel.root_dir%/Resources/serializer.json
+            - %kernel.root_dir%/Resources/serializer.xml
+            - %kernel.root_dir%/Resources/serializer.yml
+```
+
+By default, there are no global paths configured.
+
+## Annotation
+
+The bundle enables annotation support if the `AnnotationReader` class exists. If you prefer to disable it in all cases, 
+you can use:
+
+``` yaml
+ivory_serializer:
+    mapping:
+        annotations: false
+```
+
+## Reflection
+
+The bundle uses reflection by default in addition to other loaders to extract your metadatas. If you prefer disable it, 
+you can use:
+
+``` yaml
+ivory_serializer:
+    mapping:
+        reflection: false
+```
+
+## Custom
+
+If you want to programmatically register a mapping, you just need to register the loader you want and use the 
+`ivory.serializer.loader` tag. In the following example, we configure the `DirectoryClassMetadataLoader` in order to 
+load the `%kernel.root_dir%/Resources/serializer` directory.
+
+``` xml
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service
+            id="acme.serializer.loader"
+            class="Ivory\Serializer\Mapping\Loader\DirectoryClassMetadataLoader"
+        >
+            <argument>%kernel.root_dir%/Resources/serializer</argument>
+            <argument type="service" id="ivory.serializer.type.parser" />
+            <tag name="ivory.serializer.loader" />
+        </service>
+    </services>
+</container>
+```

--- a/Resources/doc/configuration/type.md
+++ b/Resources/doc/configuration/type.md
@@ -1,0 +1,50 @@
+# Type
+
+When you deserialize your data or when you configure your metadata mapping, you can specify a type. This type is not 
+mandatory except for deserializing but it is highly recommended to configure it in order to make the library faster.
+
+## Built-in
+
+The bundle integrates all the [Serializer types](https://github.com/egeloen/ivory-serializer/blob/master/doc/type.md).
+
+## Configuration
+
+Some types can be globally configured in your configuration file.
+
+### DateTime
+
+By default, the date time type uses the `DateTime::RFC3339` as format and use the `date_default_timezone_get` in order 
+to determine the timezone. If you want to override these configurations, you can use:
+
+``` yaml
+ivory_serializer:
+    types:
+        date_time:
+            format: "Y-m-d H:i:s"
+            timezone: UTC
+```
+
+## Custom
+
+If you define your own type, you need to register it by using the `ivory.serializer.type` tag and the `alias` 
+attribute representing the name of the type:
+
+``` xml
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service
+            id="acme.serializer.type.custom"
+            class="Acme\Serializer\Type\CustomType"
+        >
+            <tag name="ivory.serializer.type" alias="custom" />
+        </service>
+    </services>
+</container>
+```

--- a/Resources/doc/configuration/visitor.md
+++ b/Resources/doc/configuration/visitor.md
@@ -1,0 +1,101 @@
+# Visitors
+
+When you (de)-serialize your data, the serializer will choose a visitor according to your format (csv, json, ...) and
+your direction (serialization or deserialization). Each format/direction have a dedicated visitor in order to
+handle this specific use case.
+
+## Built-in
+
+The bundle integrates all the [Serializer visitors](https://github.com/egeloen/ivory-serializer/blob/master/doc/visitor.md).
+
+## Configuration
+
+Each visitor can be globally configured in your configuration file.
+
+### CSV
+
+The CSV visitor can be configured in order to customize how the data should be (de)-serialized when using the CSV
+format: 
+
+``` yaml
+ivory_serializer:
+    visitors:
+        csv:
+            delimiter: ","
+            enclosure: '"'
+            escape_char: "\\"
+            key_separator: "."
+```
+
+### JSON
+
+The JSON visitor can be configured in order to customize how the data should be (de)-serialized when using the JSON
+format:
+
+``` yaml
+ivory_serializer:
+    visitors:
+        json:
+            max_depth: 512
+            options: 0
+```
+
+### XML
+
+The XML visitor can be configured in order to customize how the data should be (de)-serialized when using the XML
+format:
+
+``` yaml
+ivory_serializer:
+    visitors:
+        xml:
+            version: "1.0"
+            encoding: UTF-8
+            format_output: "%kernel.debug%"
+            root: result
+            entry: entry
+            entry_attribute: key
+```
+
+### YAML
+
+The YAML visitor can be configured in order to customize how the data should be (de)-serialized when using the YAML
+format:
+
+``` yaml
+ivory_serializer:
+    visitors:
+        yaml:
+            inline: 2
+            indent: 4
+            options: 0
+```
+
+## Custom
+
+``` xml
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service
+            id="acme.serializer.visitor.custom.serialization"
+            class="Acme\Serializer\Visitor\Custom\CustomSerializationVisitor"
+        >
+            <tag name="ivory.serializer.visitor" direction="serialization" format="custom" />
+        </service>
+        
+        <service
+            id="acme.serializer.visitor.custom.deserialization"
+            class="Acme\Serializer\Visitor\Custom\CustomDeserializationVisitor"
+        >
+            <tag name="ivory.serializer.visitor" direction="deserialization" format="custom" />
+        </service>
+    </services>
+</container>
+```

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -1,0 +1,21 @@
+# Usage
+
+The bundle just integrates the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) library into Symfony.
+In order to use the library, you can fetch the serializer from the container and use it for serializing or 
+deserializing your data:
+
+``` php
+use Ivory\Serializer\Format;
+
+$stdClass = new \stdClass();
+$stdClass->foo = true;
+$stdClass->bar = ['foo', [123, 432.1]];
+
+$serializer = $container->get('ivory.serializer');
+
+echo $serializer->serialize($stdClass, Format::JSON);
+// {"foo": true,"bar": ["foo", [123, 432.1]]}
+
+$deserialize = $serializer->deserialize($json, \stdClass::class, Format::JSON);
+// $deserialize == $stdClass
+```

--- a/Tests/Fixtures/Config/Yaml/mapping_annotation_disabled.yml
+++ b/Tests/Fixtures/Config/Yaml/mapping_annotation_disabled.yml
@@ -1,3 +1,3 @@
 ivory_serializer:
     mapping:
-        annotations: false
+        annotation: false

--- a/Tests/Fixtures/Config/Yaml/mapping_cache.yml
+++ b/Tests/Fixtures/Config/Yaml/mapping_cache.yml
@@ -1,4 +1,5 @@
 ivory_serializer:
-    debug: false
     mapping:
-        cache: cache.pool
+        cache:
+            prefix: acme
+            pool: cache.custom

--- a/Tests/Fixtures/Service/class_metadata_loader.xml
+++ b/Tests/Fixtures/Service/class_metadata_loader.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+                        http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service
+            id="ivory.serializer.mapping.loader.xml"
+            class="Ivory\Serializer\Mapping\Loader\XmlClassMetadataLoader"
+        >
+            <argument>%kernel.root_dir%/Mapping/serializer.xml</argument>
+            <argument type="service" id="ivory.serializer.type.parser" />
+            <tag name="ivory.serializer.loader" />
+        </service>
+    </services>
+</container>

--- a/Tests/IvorySerializerBundleTest.php
+++ b/Tests/IvorySerializerBundleTest.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\SerializerBundle\Tests;
 
+use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterClassMetadataLoaderPass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterTypePass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterVisitorPass;
 use Ivory\SerializerBundle\IvorySerializerBundle;
@@ -46,11 +47,17 @@ class IvorySerializerBundleTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->at(0))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf(RegisterTypePass::class))
+            ->with($this->isInstanceOf(RegisterClassMetadataLoaderPass::class))
             ->will($this->returnSelf());
 
         $container
             ->expects($this->at(1))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf(RegisterTypePass::class))
+            ->will($this->returnSelf());
+
+        $container
+            ->expects($this->at(2))
             ->method('addCompilerPass')
             ->with($this->isInstanceOf(RegisterVisitorPass::class))
             ->will($this->returnSelf());


### PR DESCRIPTION
This PR introduces the `ivory.serializer.loader` tag to be able to more easily register a loader by third bundles