### PR TITLE
[Cache] Add support for Symfony < 3.1

### DIFF
--- a/DependencyInjection/Compiler/RegisterCachePoolPass.php
+++ b/DependencyInjection/Compiler/RegisterCachePoolPass.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Ivory Serializer bundle package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\SerializerBundle\DependencyInjection\Compiler;
+
+use Ivory\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class RegisterCachePoolPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($classMetadataFactoryService = 'ivory.serializer.mapping.factory')) {
+            return;
+        }
+
+        $classMetadataFactory = $container->getDefinition($classMetadataFactoryService);
+
+        if (!$classMetadataFactory->getClass() !== CacheClassMetadataFactory::class) {
+            return;
+        }
+
+        $cache = (string) $classMetadataFactory->getArgument(1);
+
+        if (class_exists(CachePoolPass::class) || $container->hasDefinition($cache)) {
+            return;
+        }
+
+        $cachePath = $container->getParameter('kernel.cache_dir').'/ivory-serializer';
+
+        $container->setDefinition(
+            $cache = 'ivory.serializer.cache',
+            new Definition(FilesystemAdapter::class, ['', 0, $cachePath])
+        );
+
+        $classMetadataFactory->replaceArgument(1, $cachePool = new Reference($cache));
+
+        $container
+            ->getDefinition('ivory.serializer.cache_warmer')
+            ->replaceArgument(2, $cachePool);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,6 +51,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('cache')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                         ->scalarNode('prefix')->defaultValue('ivory_serializer')->end()
                         ->scalarNode('pool')->defaultValue('cache.system')->end()
                     ->end()

--- a/IvorySerializerBundle.php
+++ b/IvorySerializerBundle.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\SerializerBundle;
 
+use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterCachePoolPass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterClassMetadataLoaderPass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterFOSServicePass;
 use Ivory\SerializerBundle\DependencyInjection\Compiler\RegisterListenerPass;
@@ -30,6 +31,7 @@ class IvorySerializerBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container
+            ->addCompilerPass(new RegisterCachePoolPass())
             ->addCompilerPass(new RegisterClassMetadataLoaderPass())
             ->addCompilerPass(new RegisterListenerPass())
             ->addCompilerPass(new RegisterFOSServicePass())

--- a/Resources/doc/configuration/cache.md
+++ b/Resources/doc/configuration/cache.md
@@ -1,3 +1,16 @@
 # Cache
 
-FIXME
+The cache system is enabled and used when the `kernel.debug` flag is disabled in order to increase performance of the 
+library/bundle. This means you don't really need to care about caching since by default in production, the library will 
+rely on the `cache.system` for Symfony >= 3.1 or generate a filesystem cache in the `kernel.cache_dir` of your 
+application. So, by default, everything is enabled :) 
+
+But... if you want to use your own cache strategy such as APCu, Redis, ... you can define your own PSR-6 cache pool as 
+a service and configure it with:
+
+``` yaml
+ivory_serializer:
+    mapping:
+        cache:
+            pool: acme.cache.pool
+```

--- a/Tests/Fixtures/Config/Yaml/mapping_debug.yml
+++ b/Tests/Fixtures/Config/Yaml/mapping_debug.yml
@@ -2,5 +2,3 @@ ivory_serializer:
     mapping:
         cache:
             debug: false
-            prefix: acme
-            pool: cache.custom

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": "^5.6|^7.0",
         "egeloen/serializer": "^1.0@dev",
-        "symfony/framework-bundle": "^2.7|^3.0"
+        "symfony/framework-bundle": "^2.7|^3.0",
+        "symfony/cache": "^3.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",
         "friendsofphp/php-cs-fixer": "^2.0",
         "friendsofsymfony/rest-bundle": "^2.0",
         "phpunit/phpunit": "^5.4",
-        "symfony/cache": "^3.0",
         "symfony/form": "^2.7|^3.0",
         "symfony/phpunit-bridge": "^2.7|^3.0",
         "symfony/translation": "^2.7|^3.0"

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -20,7 +20,7 @@ composer self-update
 composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
 
 if [[ "$SYMFONY_VERSION" =~ ^3\.[1-9][0-9]? ]]; then
-    composer require --no-update --dev symfony/cache:${SYMFONY_VERSION}
+    composer require --no-update symfony/cache:${SYMFONY_VERSION}
 fi
 
 composer remove --no-update --dev friendsofphp/php-cs-fixer


### PR DESCRIPTION
This PR updates the cache system in order to automatically support Symfony < 3.1 by:

 - Always install the `symfony/cache` package in order to be sure to have a PSR-6 implementation.
 - Automatically create a PSR-6 filesystem adapter using the `kernel.cache_dir` if the `cache.system` pool does not exist or no explicit cache service has been configured.